### PR TITLE
add ability to tweak height of reactor

### DIFF
--- a/assets/scripts/reactor_simulator.js
+++ b/assets/scripts/reactor_simulator.js
@@ -805,6 +805,28 @@
       optimizeInsertion();
     });
 
+    var bumpReactorSize = function(bump) {
+      var reactor = $('#reactor-area');
+      var h = reactor.data('height') + bump;
+      if (h < MIN_HEIGHT) {
+        $('#error-area').html('cannot get shorter');
+      } else if (h > MAX_HEIGHT) {
+        $('#error-area').html('cannot get taller');
+      } else {
+        var x = reactor.data('x')
+        var z = reactor.data('z')
+        updateReactor({x: x, z: z, height:h});
+      };
+    };
+
+    $('#reactor-taller').click(function() {
+      bumpReactorSize(1);
+    });
+
+    $('#reactor-shorter').click(function() {
+      bumpReactorSize(-1);
+    });
+
     $('#control-rod-insertion').slider({
       min: 0,
       max: 100,

--- a/assets/style/main.css
+++ b/assets/style/main.css
@@ -125,6 +125,10 @@ h4 {
   margin: 15px;
 }
 
+#size-controls {
+  margin: 15px;
+}
+
 #reactor-area {
   max-width: 500px;
   max-height: 500px;
@@ -272,7 +276,7 @@ h4 {
 }
 
 #controls-tabs {
-  height: 300px;
+  height: 350px;
 }
 
 .loading-animation {

--- a/index.html
+++ b/index.html
@@ -86,6 +86,15 @@
                 </button>
               </div>
 
+              <div id="size-controls">
+                <button type="button" class="btn btn-default" id="reactor-taller">
+                  <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Taller
+                </button>
+                <button type="button" class="btn btn-default" id="reactor-shorter">
+                  <span class="glyphicon glyphicon-minus" aria-hidden="true"></span> Shorter
+                </button>
+              </div>
+
               <div>
                 <input type="checkbox" id="auto-update" checked />
               </div>


### PR DESCRIPTION
I've recently been struggling when I try to find the appropriate height for my reactor to be most efficient.  I was spending a lot of time re-drawing the same reactor (and then, later, tweaking the height in the URL and refreshing).

This patch adds a set of buttons to make the reactor taller or shorter without having to resort to tricks.

NOTE:  I was not able to test it against the API, but it works fine with the "sample" request.
