### PR TITLE
Added - Ingot consumption per minute to stats

### DIFF
--- a/assets/scripts/reactor_simulator.js
+++ b/assets/scripts/reactor_simulator.js
@@ -315,6 +315,9 @@
     response.output *= modpackConfig.powerProductionMultiplier;
     response.fuelConsumption *= modpackConfig.fuelUsageMultiplier;
 
+    // Calculated value (mB per tick) * (20 tick per second) * (60 second per minute) * (1 ingot per 1000 mB)
+    response.outputIngotConsumption = response.fuelConsumption * 20 * 60 / 1000
+
     var output = response.output;
     var fuelUse = response.fuelConsumption;
     var fuelEff = output / fuelUse;

--- a/index.html
+++ b/index.html
@@ -193,6 +193,12 @@
                 <h4>Efficiency</h4>
 
                 <ul>
+
+                  <li data-for="outputIngotConsumption">
+                    <span class="value">-</span>
+                    <span class="unit">ingot/min</span>
+                  </li>
+
                   <li data-for="outputPerFuel" class="passive-only">
                     <span class="value">-</span>
                     <span class="unit">RF/mB</span>


### PR DESCRIPTION
Added simple calculation of how many ingots will be used over a course of a minute.
Math is as follows:
![daum_equation_1484009402096](https://cloud.githubusercontent.com/assets/2222562/21789670/d35b5270-d6a4-11e6-97d8-80d6d1c21370.png)

